### PR TITLE
5 add both class based and function based views at same time for comparison

### DIFF
--- a/notes/00_application_planning.md
+++ b/notes/00_application_planning.md
@@ -11,7 +11,12 @@
         * `Filament`
         * `Manufacturer`
 
+## User Flow for Create `ModelPrint`:
+1. Function-based may be best option since we need to create a `FilamentInstance` just in time for the creation of `ModelPrint` instances.
+    * Maybe use `form_valid()`?
 
+## Ideas:
+* How to delete and incorrectly entered `ModelPrint` instance and `FilamentInstance` instance?
 
 
 ## Repository Links:

--- a/notes/00_model_planning.md
+++ b/notes/00_model_planning.md
@@ -43,6 +43,7 @@
             * Name of the filament manufacturer.
         * OTHER_ATTRIBUTES
 
+
 ## Repository Links:
 * [Application Planning](./00_application_planning.md)
 * [README.md](../README.md)

--- a/notes/16_filament_roll_create_view.md
+++ b/notes/16_filament_roll_create_view.md
@@ -75,7 +75,7 @@
         )
     ```
 
-1. Add route `print/create-model-print/` to [`prints/urls.py`](../prints/urls.py):
+1. Add route `print/create-filament-roll/` to [`prints/urls.py`](../prints/urls.py):
     ```
     urlpatterns = [
         #...
@@ -87,7 +87,6 @@
 1. Test new views:
     * `python .\manage.py runserver`
     * http://localhost:8000/prints/print/create-model-print/
-
 
 1. Proceed to []()
 

--- a/prints/forms.py
+++ b/prints/forms.py
@@ -8,11 +8,10 @@ class CreateModelPrintForm(forms.Form):
         label='Model Print Name',
         max_length=255,
     )
-    filament_consumed = forms.CharField(
+    filament_consumed = forms.IntegerField(
         label="Filament Consumed",
         help_text='Units of grams (g)',
-        max_length=100,
-        widget=forms.NumberInput(),
+        min_value=0,
     )
     filament_roll_chosen = forms.ModelChoiceField(
         label='Filament Roll Chosen',

--- a/prints/models.py
+++ b/prints/models.py
@@ -63,7 +63,8 @@ class ModelPrint(models.Model):
             f'{self.id} : '
             f'{self.name} : '
             f'{self.creator.username} : '
-            f'{self.filament_instance.filament_roll if self.filament_instance else "No filament_instance provided"}'
+            f'{self.filament_instance.filament_consumed if self.filament_instance else "No FilamentInstance provided"} grams of '
+            f'"{self.filament_instance.filament_roll if self.filament_instance else "No FilamentInstance provided"}"'
         )
     
     def get_absolute_url(self):

--- a/prints/urls.py
+++ b/prints/urls.py
@@ -6,7 +6,13 @@ app_name = 'prints'
 urlpatterns = [
     path('', views.ModelPrintListView.as_view(), name='home'),
 
-    path('print/create-model-print/', views.create_model_print, name='create_model_print'),
+    path(
+        'print/cb-create-model-print/',
+        views.ModelPrintCreateView.as_view(),
+        name='cb_create_model_print'
+    ),
+
+    path('print/create-model-print/', views.model_print_create_function, name='model_print_create'),
     path('print/create-filament-roll/', views.create_filament_roll, name='create_filament_roll'),
 
     path('print/<int:pk>/', views.ModelPrintDetailView.as_view(), name='model_detail'),

--- a/prints/urls.py
+++ b/prints/urls.py
@@ -12,10 +12,30 @@ urlpatterns = [
         name='cb_create_model_print'
     ),
 
-    path('print/create-model-print/', views.model_print_create_function, name='model_print_create'),
-    path('print/create-filament-roll/', views.create_filament_roll, name='create_filament_roll'),
+    path(
+        'print/create-model-print/',
+        views.model_print_create_function,
+        name='create_model_print'
+    ),
+    path(
+        'print/create-filament-roll/',
+        views.create_filament_roll,
+        name='create_filament_roll'
+    ),
 
-    path('print/<int:pk>/', views.ModelPrintDetailView.as_view(), name='model_detail'),
-    path('print/<int:pk>/edit/', views.ModelPrintUpdateView.as_view(), name='model_update'),
-    path('print/<int:pk>/delete/', views.ModelPrintDeleteView.as_view(), name='model_delete'),
+    path(
+        'print/<int:pk>/',
+        views.ModelPrintDetailView.as_view(),
+        name='model_detail'
+    ),
+    path(
+        'print/<int:pk>/edit/',
+        views.ModelPrintUpdateView.as_view(),
+        name='model_update'
+    ),
+    path(
+        'print/<int:pk>/delete/',
+        views.ModelPrintDeleteView.as_view(),
+        name='model_delete'
+    ),
 ]

--- a/prints/urls.py
+++ b/prints/urls.py
@@ -7,9 +7,15 @@ urlpatterns = [
     path('', views.ModelPrintListView.as_view(), name='home'),
 
     path(
-        'print/cb-create-model-print/',
+        'print/model-print-form-view/',
+        views.ModelPrintFormView.as_view(),
+        name='model_print_form_view',
+    ),
+
+    path(
+        'print/model-print-create-view/',
         views.ModelPrintCreateView.as_view(),
-        name='cb_create_model_print'
+        name='model_print_create_view'
     ),
 
     path(

--- a/prints/views.py
+++ b/prints/views.py
@@ -8,6 +8,7 @@ from django.views.generic.edit import CreateView
 from django.views.generic.edit import UpdateView
 from django.views.generic.edit import DeleteView
 from django.views.generic.edit import FormView
+from django.views.generic.edit import FormMixin
 
 from django.contrib import auth
 
@@ -53,41 +54,74 @@ def create_filament_roll(request):
         material=current_material,
     )
     return HttpResponseRedirect(
-        reverse('prints:model_print_create')
+        reverse('prints:create_model_print')
     )
 
+"""
+from myapp.forms import ContactForm
+from django.views.generic.edit import FormView
 
-class ModelPrintCreateView(LoginRequiredMixin, CreateView):
+class ContactFormView(FormView):
+    template_name = 'contact.html'
+    form_class = ContactForm
+    success_url = '/thanks/'
+
+    def form_valid(self, form):
+        # This method is called when valid form data has been POSTed.
+        # It should return an HttpResponse.
+        form.send_email()
+        return super().form_valid(form)
+"""
+
+class ModelPrintCreateView(LoginRequiredMixin, FormView):
     """
     Class-based view to create `ModelPrint` instances.
     """
-    # model = ModelPrint
-    # template_name = 'cb_model_print_create.html'
-    # # Using ModelFormMixin (base class of ModelPrintCreateView) without the 'fields' attribute is prohibited.
-
-    # form = CreateModelPrintForm
-    # template_name ='cb_model_print_create.html'
-    # # ModelPrintCreateView is missing a QuerySet. Define ModelPrintCreateView.model, ModelPrintCreateView.queryset, or override ModelPrintCreateView.get_queryset().
-    
-    ##### SUCCESS #####
-    model = ModelPrint
     template_name = 'cb_model_print_create.html'
-    fields = [
-        'name',
-        'creator',
-        'filament_instance',
-    ]
-    ###################
+    form_class = CreateModelPrintForm
+    
+    def form_valid(self, form):
+        print("'form_valid()' has been called")
+        # This method is called when valid form data has been POSTed.
+        # It should return an HttpResponse.
 
+        # print('type(self): ', type(self))
+        # # type(self):  <class 'prints.views.ModelPrintCreateView'>
+        # print('type(form): ', type(form))
+        # # type(form):  <class 'prints.forms.CreateModelPrintForm'>
+
+        print('form.cleaned_data: ', form.cleaned_data)
+        # # form.cleaned_data:  {
+        # #     'model_print_name': 'Totally New Print',
+        # #     'filament_consumed': 2,
+        # #     'filament_roll_chosen': <FilamentRoll: 28 - Manufacturer To Delete - Material To Delete>
+        # # }
+
+        return super().form_valid(form)
+
+    # We want to give the template the current `FilamentRoll`s.
+    def get_context_data(self,**kwargs):
+        print("'get_context_data()' has been called")
+        context = super().get_context_data(**kwargs)
+        # Here we are adding more 'context' attributes.
+        # print('context: ', context)
+        # # context:  {
+        # #     'form': <CreateModelPrintForm bound=False, valid=Unknown, fields=(model_print_name;filament_consumed;filament_roll_chosen)>,
+        # #     'view': <prints.views.ModelPrintCreateView object at 0x000001DEDA8A2800>
+        # # }
+
+        context['filament_rolls'] = FilamentRoll.objects.all()
+        # print('context: ', context)
+        return context
+
+    # Can I somehow pass the id of the newly created model `ModelPrint` to `get_success_url`?
     def get_success_url(self):
-        print('self: ', self)
-        # self:  <prints.views.ModelPrintCreateView object at 0x0000018AC1FF1FF0>
-        print('self.object: ', self.object)
-        # `self.object` returns the object created by the view:
-            # self.object:  38 : Stupor Model : NotAnAdmin : 7 - Inland - PLA+
+        print("'get_success_url()' has been called")
+        # print('self: ', self)
+        # # self:  <prints.views.ModelPrintCreateView object at 0x0000018AC1FF1FF0>
+
         return reverse(
-            'prints:model_detail',
-            kwargs={ 'pk': self.object.id}
+            'prints:create_model_print',
         )
 
 

--- a/prints/views.py
+++ b/prints/views.py
@@ -7,6 +7,7 @@ from django.views.generic import DetailView
 from django.views.generic.edit import CreateView
 from django.views.generic.edit import UpdateView
 from django.views.generic.edit import DeleteView
+from django.views.generic.edit import FormView
 
 from django.contrib import auth
 
@@ -52,11 +53,45 @@ def create_filament_roll(request):
         material=current_material,
     )
     return HttpResponseRedirect(
-        reverse('prints:create_model_print')
+        reverse('prints:model_print_create')
     )
 
 
-def create_model_print(request):
+class ModelPrintCreateView(LoginRequiredMixin, CreateView):
+    """
+    Class-based view to create `ModelPrint` instances.
+    """
+    # model = ModelPrint
+    # template_name = 'cb_model_print_create.html'
+    # # Using ModelFormMixin (base class of ModelPrintCreateView) without the 'fields' attribute is prohibited.
+
+    # form = CreateModelPrintForm
+    # template_name ='cb_model_print_create.html'
+    # # ModelPrintCreateView is missing a QuerySet. Define ModelPrintCreateView.model, ModelPrintCreateView.queryset, or override ModelPrintCreateView.get_queryset().
+    
+    ##### SUCCESS #####
+    model = ModelPrint
+    template_name = 'cb_model_print_create.html'
+    fields = [
+        'name',
+        'creator',
+        'filament_instance',
+    ]
+    ###################
+
+    def get_success_url(self):
+        print('self: ', self)
+        # self:  <prints.views.ModelPrintCreateView object at 0x0000018AC1FF1FF0>
+        print('self.object: ', self.object)
+        # `self.object` returns the object created by the view:
+            # self.object:  38 : Stupor Model : NotAnAdmin : 7 - Inland - PLA+
+        return reverse(
+            'prints:model_detail',
+            kwargs={ 'pk': self.object.id}
+        )
+
+
+def model_print_create_function(request):
     
     if request.method == 'POST':
         filament_roll_id = request.POST.get('filament_roll_chosen')

--- a/prints/views.py
+++ b/prints/views.py
@@ -47,69 +47,148 @@ class ModelPrintDetailView(DetailView):
 
 
 def create_filament_roll(request):
+    # print(request)
+    # print('dir(request): ', dir(request))
+    # print('request.path: ', request.path)
+    # print('request.headers: ', request.headers)
+    print("request.headers['Origin']: ", request.headers['Origin'])
+    print("request.headers['Referer']: ", request.headers['Referer'])
+
+    the_origin = request.headers['Origin']
+    the_referer = request.headers['Referer']
+    the_url_we_want_to_go = the_referer.replace(the_origin, '')
+    print('the_url_we_want_to_go: ', the_url_we_want_to_go)
+
     current_manufacturer = request.POST.get('manufacturer')
     current_material = request.POST.get('material')
     new_filament_roll = FilamentRoll.objects.create(
         manufacturer=current_manufacturer,
         material=current_material,
     )
+    return HttpResponseRedirect(the_url_we_want_to_go)
     return HttpResponseRedirect(
         reverse('prints:create_model_print')
     )
 
 
+class ModelPrintFormView(LoginRequiredMixin, FormView):
+    """
+    Class-based `FormView` to create `ModelPrint` instance.
+    """
+    form_class = CreateModelPrintForm
+    template_name = 'model_print_create_fv.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        filament_roll_form = CreateFilamentRollForm()
+        context['filament_roll_form'] = filament_roll_form
+
+        filament_rolls = FilamentRoll.objects.all()
+        context['filament_rolls_in_template'] = filament_rolls
+
+        hard_coded_view_name = 'model_print_form_view'
+        context['the_view_name'] = hard_coded_view_name
+        print("'get_context_data()' has been called: ", context['the_view_name'])
+        return context
+
+    def get_success_url(self, model_print=None):
+        the_url = reverse('prints:model_detail', kwargs={ 'pk': model_print.id})
+        print("'get_success_url()' has been called: ", the_url)
+        return the_url
+
+    def form_valid(self, form):
+        print("'form_valid() has been called:")
+
+        current_filament_roll = form.cleaned_data['filament_roll_chosen']
+        print('current_filament_roll: ', current_filament_roll)
+
+        current_filament_consumed = form.cleaned_data['filament_consumed']
+        print('current_filament_consumed: ', current_filament_consumed)
+
+        current_model_print_name = form.cleaned_data['model_print_name']
+        print('current_model_print_name: ', current_model_print_name)
+
+        current_user = auth.get_user(self.request)
+        print('current_user: ', current_user)
+
+        new_filament_instance = FilamentInstance.objects.create(
+            filament_consumed=current_filament_consumed,
+            filament_roll=current_filament_roll,
+        )
+
+        new_model_print = ModelPrint.objects.create(
+            name=current_model_print_name,
+            creator=current_user,
+            filament_instance=new_filament_instance,
+        )
+        print('new_model_print: ', new_model_print)
+
+        the_success_url = self.get_success_url(new_model_print)
+
+        return HttpResponseRedirect(the_success_url)
+
 
 class ModelPrintCreateView(LoginRequiredMixin, CreateView):
     """
-    Class-based view to create `ModelPrint` instances.
+    Class-based `CreateView` to create `ModelPrint` instance.
+
+    This view doesn't function as needed yet. Haven't figured out how to programmatically create `FilemantInstance`.
     """
     model = ModelPrint
-    template_name = 'cb_model_print_create.html'
+    template_name = 'model_print_create_cv.html'
     fields = [
         'name',
         'filament_instance',
     ]
+    
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        filament_roll_form = CreateFilamentRollForm()
+        context['filament_roll_form'] = filament_roll_form
+
+        filament_rolls = FilamentRoll.objects.all()
+        context['filament_rolls_in_template'] = filament_rolls
+
+        hard_coded_view_name = 'model_print_create_view'
+        context['the_view_name'] = hard_coded_view_name
+
+        print("'get_context_data()' has been called: ", context['the_view_name'])
+        return context
+
+    def get_success_url(self):
+        new_model_print = self.object
+        the_url = reverse('prints:model_detail', kwargs={ 'pk': new_model_print.id})
+        print("'get_success_url()' has been called: ", the_url)
+        return the_url
 
     def form_valid(self, form):
         print("'form_valid()' has been called:")
-        # print('self: ', self)
-        # # self:  <prints.views.ModelPrintCreateView object at 0x000002B6B3A81780>
-        # print('form: ', form)
-        # # An HTML form.
         form.instance.creator = self.request.user
         return super(ModelPrintCreateView, self).form_valid(form)
-    
-    def get_success_url(self):
-        print("'get_success_url()' has been called:")
-        # print('type(self.object): ', type(self.object))
-        # # type(self.object):  <class 'prints.models.ModelPrint'>
-        print('self.object.name: ', self.object.name)
-        print('self.object.id: ', self.object.id)
-        new_model_print = self.object
-        return reverse('prints:model_detail', kwargs={ 'pk': new_model_print.id})
 
 
 def model_print_create_function(request):
+    print("'model_print_create_function()' has been called:")
     
     if request.method == 'POST':
         filament_roll_id = request.POST.get('filament_roll_chosen')
 
-        # Create a current `FilamentInstance` from user input:
         current_filament_roll = get_object_or_404(
             FilamentRoll,
             pk=filament_roll_id
         )
         current_filament_consumed = request.POST.get('filament_consumed')
-        current_filament_instance = FilamentInstance.objects.create(
+        new_filament_instance = FilamentInstance.objects.create(
             filament_roll=current_filament_roll,
             filament_consumed=current_filament_consumed,
         )
 
-        # Create a new `ModelPrint` from user input and `auth.get_user()`:
         current_model_print_name = request.POST.get('model_print_name')
         current_user = auth.get_user(request)
         new_model_print = ModelPrint.objects.create(
-            filament_instance=current_filament_instance,
+            filament_instance=new_filament_instance,
             name=current_model_print_name,
             creator=current_user,
         )
@@ -124,6 +203,10 @@ def model_print_create_function(request):
             'model_print_form': create_model_print_form,
             'filament_roll_form': create_filament_roll_form,
         }
+
+        filament_rolls = FilamentRoll.objects.all()
+        context['filament_rolls_in_template'] = filament_rolls
+
         return render(
             request,
             'model_print_create.html',

--- a/prints/views.py
+++ b/prints/views.py
@@ -57,72 +57,36 @@ def create_filament_roll(request):
         reverse('prints:create_model_print')
     )
 
-"""
-from myapp.forms import ContactForm
-from django.views.generic.edit import FormView
 
-class ContactFormView(FormView):
-    template_name = 'contact.html'
-    form_class = ContactForm
-    success_url = '/thanks/'
 
-    def form_valid(self, form):
-        # This method is called when valid form data has been POSTed.
-        # It should return an HttpResponse.
-        form.send_email()
-        return super().form_valid(form)
-"""
-
-class ModelPrintCreateView(LoginRequiredMixin, FormView):
+class ModelPrintCreateView(LoginRequiredMixin, CreateView):
     """
     Class-based view to create `ModelPrint` instances.
     """
+    model = ModelPrint
     template_name = 'cb_model_print_create.html'
-    form_class = CreateModelPrintForm
-    
+    fields = [
+        'name',
+        'filament_instance',
+    ]
+
     def form_valid(self, form):
-        print("'form_valid()' has been called")
-        # This method is called when valid form data has been POSTed.
-        # It should return an HttpResponse.
-
-        # print('type(self): ', type(self))
-        # # type(self):  <class 'prints.views.ModelPrintCreateView'>
-        # print('type(form): ', type(form))
-        # # type(form):  <class 'prints.forms.CreateModelPrintForm'>
-
-        print('form.cleaned_data: ', form.cleaned_data)
-        # # form.cleaned_data:  {
-        # #     'model_print_name': 'Totally New Print',
-        # #     'filament_consumed': 2,
-        # #     'filament_roll_chosen': <FilamentRoll: 28 - Manufacturer To Delete - Material To Delete>
-        # # }
-
-        return super().form_valid(form)
-
-    # We want to give the template the current `FilamentRoll`s.
-    def get_context_data(self,**kwargs):
-        print("'get_context_data()' has been called")
-        context = super().get_context_data(**kwargs)
-        # Here we are adding more 'context' attributes.
-        # print('context: ', context)
-        # # context:  {
-        # #     'form': <CreateModelPrintForm bound=False, valid=Unknown, fields=(model_print_name;filament_consumed;filament_roll_chosen)>,
-        # #     'view': <prints.views.ModelPrintCreateView object at 0x000001DEDA8A2800>
-        # # }
-
-        context['filament_rolls'] = FilamentRoll.objects.all()
-        # print('context: ', context)
-        return context
-
-    # Can I somehow pass the id of the newly created model `ModelPrint` to `get_success_url`?
-    def get_success_url(self):
-        print("'get_success_url()' has been called")
+        print("'form_valid()' has been called:")
         # print('self: ', self)
-        # # self:  <prints.views.ModelPrintCreateView object at 0x0000018AC1FF1FF0>
-
-        return reverse(
-            'prints:create_model_print',
-        )
+        # # self:  <prints.views.ModelPrintCreateView object at 0x000002B6B3A81780>
+        # print('form: ', form)
+        # # An HTML form.
+        form.instance.creator = self.request.user
+        return super(ModelPrintCreateView, self).form_valid(form)
+    
+    def get_success_url(self):
+        print("'get_success_url()' has been called:")
+        # print('type(self.object): ', type(self.object))
+        # # type(self.object):  <class 'prints.models.ModelPrint'>
+        print('self.object.name: ', self.object.name)
+        print('self.object.id: ', self.object.id)
+        new_model_print = self.object
+        return reverse('prints:model_detail', kwargs={ 'pk': new_model_print.id})
 
 
 def model_print_create_function(request):

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,12 +34,17 @@
             <a
                 href={% url 'prints:create_model_print' %}
                 >
-                Add New 3D Model Print : function-based
+                Add New 3D Model Print : create_model_print
             </a><br>
             <a
-                href={% url 'prints:cb_create_model_print' %}
+                href={% url 'prints:model_print_create_view' %}
                 >
-                Add New 3D Model Print : class-based
+                Add New 3D Model Print : model_print_create_view [CURRENTLY UNDER CONSTRUCTION]
+            </a><br>
+            <a
+                href={% url 'prints:model_print_form_view' %}
+                >
+                Add New 3D Model Print : model_print_form_view
             </a><br>
             {% endif %}
             {% block content %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,9 +32,14 @@
             {% endif %}
             {% if user.is_authenticated %}
             <a
-                href={% url 'prints:create_model_print' %}
+                href={% url 'prints:model_print_create' %}
                 >
-                Add New 3D Model Print
+                Add New 3D Model Print : function-based
+            </a><br>
+            <a
+                href={% url 'prints:cb_create_model_print' %}
+                >
+                Add New 3D Model Print : class-based
             </a><br>
             {% endif %}
             {% block content %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,7 @@
             {% endif %}
             {% if user.is_authenticated %}
             <a
-                href={% url 'prints:model_print_create' %}
+                href={% url 'prints:create_model_print' %}
                 >
                 Add New 3D Model Print : function-based
             </a><br>

--- a/templates/base.html
+++ b/templates/base.html
@@ -39,7 +39,7 @@
             <a
                 href={% url 'prints:model_print_create_view' %}
                 >
-                Add New 3D Model Print : model_print_create_view [CURRENTLY UNDER CONSTRUCTION]
+                Add New 3D Model Print : model_print_create_view
             </a><br>
             <a
                 href={% url 'prints:model_print_form_view' %}

--- a/templates/cb_model_print_create.html
+++ b/templates/cb_model_print_create.html
@@ -4,14 +4,26 @@
 
 {% block content %}
 
-<h2>Create New 3D Model Print</h2>
-<form action="{% url 'prints:cb_create_model_print' %}" method="post">
+{% comment %} <h2>Create New 3D Model Print : {{ the_view_name }}</h2> {% endcomment %}
+<h2>Create New 3D Model Print : model_print_form_view</h2>
+<form action="{% url 'prints:model_print_form_view' %}" method="post">
+    {% csrf_token %}
+    
+    {{ form.as_p }}
+    
+    <input type="submit" value="Create New 3D Model Print" />
+</form>
+
+<h2>Create New 3D Model Print : model_print_create_view</h2>
+{% comment %} <h2>Create New 3D Model Print : {{ the_view_name }}</h2> {% endcomment %}
+<form action="{% url 'prints:model_print_create_view' %}" method="post">
     {% csrf_token %}
 
     {{ form.as_p }}
 
     <input type="submit" value="Create New 3D Model Print" />
 </form>
+
 
 <h2>Create New Filament Roll</h1>
 <h3>UNDER CONSTRUCTION</h3>

--- a/templates/cb_model_print_create.html
+++ b/templates/cb_model_print_create.html
@@ -5,10 +5,10 @@
 {% block content %}
 
 <h2>Create New 3D Model Print</h2>
-<form action="{% url 'prints:model_print_create' %}" method="post">
+<form action="{% url 'prints:cb_create_model_print' %}" method="post">
     {% csrf_token %}
 
-    {{ model_print_form.as_p }}
+    {{ form.as_p }}
 
     <input type="submit" value="Create New 3D Model Print" />
 </form>

--- a/templates/cb_model_print_create.html
+++ b/templates/cb_model_print_create.html
@@ -14,12 +14,13 @@
 </form>
 
 <h2>Create New Filament Roll</h1>
-<form action="{% url 'prints:create_filament_roll' %}" method="post">
+<h3>UNDER CONSTRUCTION</h3>
+{% comment %} <form action="{% url 'prints:create_filament_roll' %}" method="post">
     {% csrf_token %}
 
     {{ filament_roll_form.as_p }}
 
     <input type="submit" value="Create New Filament Roll" />
-</form>
+</form> {% endcomment %}
 
 {% endblock %}

--- a/templates/model_print_create.html
+++ b/templates/model_print_create.html
@@ -5,7 +5,7 @@
 {% block content %}
 
 <h2>Create New 3D Model Print</h2>
-<form action="{% url 'prints:model_print_create' %}" method="post">
+<form action="{% url 'prints:create_model_print' %}" method="post">
     {% csrf_token %}
 
     {{ model_print_form.as_p }}

--- a/templates/model_print_create_cv.html
+++ b/templates/model_print_create_cv.html
@@ -10,7 +10,21 @@
     {% csrf_token %}
     
     {{ form.as_p }}
-    
+
+    <p>
+    <label for="filament-consumed-input">Filament Consumed</label>
+    <input type="number" name="filament_consumed" id="filament-consumed-input" placeholder="Filament Consumed">
+    </p>
+
+    <p>
+    <label for="filament-roll-input">Filament Roll Chosen:</label>
+    <select name="filament_roll" id="filament-roll-input">
+        {% for filament_roll in filament_rolls_in_template %}
+        <option value="{{ filament_roll.id }}">{{ filament_roll }}</option>
+        {% endfor %}
+    </select>
+    </p>
+
     <input type="submit" value="Create New 3D Model Print" />
 </form>
 

--- a/templates/model_print_create_cv.html
+++ b/templates/model_print_create_cv.html
@@ -4,13 +4,13 @@
 
 {% block content %}
 
-<h1><code>model_print_create_function()</code></h1>
-<h2>Create New 3D Model Print</h2>
-<form action="{% url 'prints:create_model_print' %}" method="post">
+<h1><code>CreateView</code></h1>
+<h2>Create New 3D Model Print : {{ the_view_name }}</h2>
+<form action="{% url 'prints:model_print_create_view' %}" method="post">
     {% csrf_token %}
-
-    {{ model_print_form.as_p }}
-
+    
+    {{ form.as_p }}
+    
     <input type="submit" value="Create New 3D Model Print" />
 </form>
 

--- a/templates/model_print_create_fv.html
+++ b/templates/model_print_create_fv.html
@@ -4,13 +4,13 @@
 
 {% block content %}
 
-<h1><code>model_print_create_function()</code></h1>
-<h2>Create New 3D Model Print</h2>
-<form action="{% url 'prints:create_model_print' %}" method="post">
+<h1><code>FormView</code></h1>
+<h2>Create New 3D Model Print : {{ the_view_name }}</h2>
+<form action="{% url 'prints:model_print_form_view' %}" method="post">
     {% csrf_token %}
-
-    {{ model_print_form.as_p }}
-
+    
+    {{ form.as_p }}
+    
     <input type="submit" value="Create New 3D Model Print" />
 </form>
 
@@ -22,7 +22,7 @@
 
     <input type="submit" value="Create New Filament Roll" />
 </form>
-
+    
 <h2>List of Filament Rolls</h2>
 {% for filament_roll in filament_rolls_in_template %}
     {{ filament_roll }}<br>

--- a/templates/model_print_detail.html
+++ b/templates/model_print_detail.html
@@ -8,7 +8,7 @@ User: {{ user.username | capfirst }}<br>
 ModelPrint Creator: {{ modelprint.creator.username | capfirst }}<br>
 User is the 3D Model Print Creator: {% if user.id == modelprint.creator.id %} Yep! {% else %} Nope! {% endif %}
 
-<h2>Model Detail</h2>
+<h2>Model Print Detail</h2>
 {{ modelprint.name }}<br>
 {{ modelprint.filament_instance.filament_consumed }} grams of {{ modelprint.filament_instance.filament_roll }} used.<br>
 {{ modelprint.creator.username }}<br>


### PR DESCRIPTION
This was a learning exercise.
* `model_print_create_function`:
    * Interesting since I made commands to do 'raw' stuff in Python.
    * Learned how to use `POST` and `GET` blocks.
* `ModelPrintFormView`:
    * Made it easy to use a `form`:
        * This was handy since I wanted to use an attribute of `FilamentInstance` in `ModelPrint` form.
        * This was handy since I wanted to select from a list of `FilamentRoll`s.
* `ModelPrintCreateView`:
    * Seemed the least handy:
        * Only used one `ModelPrint` field in `fields` attribute: `name`
        * Had to hard-code form elements in template:
            * There is probably a way to create a form for use in a `CreateView`, but will have to research further.
        * Had to cram creation of two instances in `form_valid()` rather than letting Django do the work for me:
            * `FilamentInstance`
            * `ModelPrint`